### PR TITLE
Fix FlatList keyExtractor error

### DIFF
--- a/src/SelectDropdown.js
+++ b/src/SelectDropdown.js
@@ -332,7 +332,7 @@ const SelectDropdown = (
             ) : (
               <FlatList
                 data={data}
-                keyExtractor={(item, index) => index}
+                keyExtractor={(item, index) => index.toString()}
                 ref={(ref) => (dropDownFlatlistRef.current = ref)}
                 renderItem={renderFlatlistItem}
                 getItemLayout={(data, index) => ({


### PR DESCRIPTION
This fix resolves:
Warning: Failed child context type: Invalid child context `virtualizedCell.cellKey` of type `number` supplied to `CellRenderer`, expected `string`.