### PR TITLE
Allow backdrop color customization through props

### DIFF
--- a/src/SelectDropdown.js
+++ b/src/SelectDropdown.js
@@ -40,6 +40,7 @@ const SelectDropdown = (
     dropdownIconPosition,
     statusBarTranslucent,
     dropdownStyle,
+    dropdownOverlayColor /* backdrop color when dropdown is opened */,
     /////////////////////////////
     rowStyle /* style object for row */,
     rowTextStyle /* style object for row text */,
@@ -313,7 +314,10 @@ const SelectDropdown = (
         >
           <TouchableOpacity
             activeOpacity={1}
-            style={[styles.dropdownOverlay]}
+            style={[
+              styles.dropdownOverlay, 
+              !!dropdownOverlayColor && { backgroundColor: dropdownOverlayColor }
+            ]}
             onPress={() => closeDropdown()}
           />
           <View


### PR DESCRIPTION
PR adds ability to customize dropdown overlay background color through `dropdownOverlayColor` prop, since the default overlay color may be too strong or may not fit design.