### PR TITLE
Added support for theming the dropdown background color.

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,15 @@ backdrop color when dropdown is opened
 | string | No       |
 
 ---
+### dropdownBackgroundColor
+
+background color behind list items when dropdown is opened
+
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
+
+---
 
 ### rowStyle
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ const countries = ["Egypt", "Canada", "Australia", "Ireland"]
 
 - [`dropdownOverlayColor`](#dropdownOverlayColor)
 
+- [`dropdownBackgroundColor`](#dropdownBackgroundColor)
+
 - [`rowStyle`](#rowStyle)
 
 - [`rowTextStyle`](#rowTextStyle)
@@ -269,6 +271,7 @@ backdrop color when dropdown is opened
 | string | No       |
 
 ---
+
 ### dropdownBackgroundColor
 
 background color behind list items when dropdown is opened

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import type * as React from 'react';
+import type * as React from "react";
 import { StyleProp, ViewStyle, TextStyle } from "react-native";
 
 declare module "react-native-select-dropdown" {
@@ -71,6 +71,10 @@ declare module "react-native-select-dropdown" {
      * backdrop color when dropdown is opened 
      */
     dropdownOverlayColor?: string;
+    /**
+     * background color behind list items when dropdown is opened
+     */
+    dropdownBackgroundColor?: string;
     /**
      * style object for row
      */

--- a/src/SelectDropdown.js
+++ b/src/SelectDropdown.js
@@ -42,6 +42,7 @@ const SelectDropdown = (
     statusBarTranslucent,
     dropdownStyle,
     dropdownOverlayColor /* string */,
+    dropdownBackgroundColor /* string */,
     /////////////////////////////
     rowStyle /* style object for row */,
     rowTextStyle /* style object for row text */,
@@ -355,6 +356,11 @@ const SelectDropdown = (
             ) : (
               <FlatList
                 data={data}
+                style={[
+                  !!dropdownBackgroundColor && {
+                    backgroundColor: dropdownBackgroundColor,
+                  },
+                ]}
                 keyExtractor={(item, index) => index.toString()}
                 ref={(ref) => (dropDownFlatlistRef.current = ref)}
                 renderItem={renderFlatlistItem}


### PR DESCRIPTION
I found that the dropdown background was white when trying to allow for light/dark theming in my application. It appears  primarily as an issue for iOS with its ability to scroll beyond the top/bottom of a list slightly by continuing to pull beyond the end of the list.

I have added functionality to allow the user to provide the background color of the dropdown, similar to how the user can already provide the dropdownOverlayColor parameter and change the overlay color.

I have included screenshots to show the functionality in action. In this case, I am setting the color of the background to match the color of the buttons in the dropdown.

Before
![image](https://user-images.githubusercontent.com/45803717/152633698-bc22a3de-8021-445d-b2a8-f68537422923.png)

After
![image](https://user-images.githubusercontent.com/45803717/152633702-aa4a1ccf-fffe-4612-9505-fc4bd8d2dfd4.png)

---

I also noticed an inconsistent use of quotes instead of double quotes for the react import in index.d.ts
