### PR TITLE
Add selectItem method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -143,7 +143,7 @@ declare module "react-native-select-dropdown" {
      */
     closeDropdown(): void;
     /**
-     * Select a specific element with its index.
+     * Select a specific item with its index.
      */
     selectItem(item: any, index: number): void;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -142,5 +142,9 @@ declare module "react-native-select-dropdown" {
      * Close the dropdown.
      */
     closeDropdown(): void;
+    /**
+     * Select a specific element with its index.
+     */
+    selectItem(item: any, index: number): void;
   }
 }

--- a/src/SelectDropdown.js
+++ b/src/SelectDropdown.js
@@ -60,6 +60,9 @@ const SelectDropdown = (
     closeDropdown: () => {
       closeDropdown();
     },
+    selectItem: (item, index) => {
+      onSelectItem(item, index);
+    }
   }));
   ///////////////////////////////////////////////////////
   const DropdownButton = useRef(); // button ref to get positions


### PR DESCRIPTION
## Description of the PR
This Pull Request adds the `selectItem` method to the list of methods accessible from the `ref` of the component.
**This modification allows developers to change the selected value of the selector component from outside the component.**

## Purpose
I'm bringing this method because I'm in a situation where I need to set a value for this selector from outside the selector. And I think adding it from the `ref` would be much easier.

I look forward to reading your thoughts on whether this feature helps, or how to improve this feature.

Regards!

Closes #71.
