### PR TITLE
Remove the array.push(null) when populating the search array

### DIFF
--- a/src/helpers/deepSearchInArr.js
+++ b/src/helpers/deepSearchInArr.js
@@ -30,8 +30,6 @@ export const deepSearchInArr = (query, arr) => {
   for (let i = 0; i <= arr.length - 1; i++) {
     if (contains(query, arr[i])) {
       array.push(arr[i]);
-    } else {
-      array.push(null);
     }
     if (i == arr.length - 1) {
       return array;


### PR DESCRIPTION
Hello,
My SelectDropdown contains 150 elements and when i'm searching for the last elements, they doesnt show in the results array.
After removing the array.push(null) in the results array, I can see them.
I dont know what could be the consequences of this removal, I'm looking for your analyse.
Thank you