### PR TITLE
Move the dropdown Y up 25 pixels on Android only

### DIFF
--- a/src/SelectDropdown.js
+++ b/src/SelectDropdown.js
@@ -114,13 +114,15 @@ const SelectDropdown = (
   const openDropdown = () => {
     DropdownButton.current.measure((fx, fy, w, h, px, py) => {
       // console.log('position y => ', py, '\nheight', h, '\nposition x => ', px)
+      // Y location is offset 25 pixels below the SelectDropdown on Android
+      const offset = (Platform.OS == 'android' ? 25 : 0);
       setButtonLayout({w, h, px, py});
       if (height - 18 < py + h + dropdownHEIGHT) {
         setDropdownPX(px);
         setDropdownPY(py - 2 - dropdownHEIGHT);
       } else {
         setDropdownPX(px);
-        setDropdownPY(py + h + 2);
+        setDropdownPY(py + h + 2 - offset);
       }
       setDropdownWIDTH(dropdownStyle?.width || w);
       setIsVisible(true);


### PR DESCRIPTION
When the user taps on the SelectDropdown object, the rows of selectable items are displayed 25 pixels below the object.  Subtract the offset from the Y value when on Android only.

I have tested this change on my device and emulators of varying sizes.  It's always 25 pixels.