### PR TITLE
Update dropdownWindowStyle and renderCustomizedRowChild

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,6 +40,10 @@ declare module "react-native-select-dropdown" {
      */
     disableAutoScroll?: boolean;
     /**
+     * disable click all Rows index in the list
+     */
+     disabledIndexs?: number[];
+    /**
       * function fires when dropdown is opened
       */
     onFocus?: () => void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -98,7 +98,7 @@ declare module "react-native-select-dropdown" {
     /**
      * function recieves item and its index, this function should return React component as a child for customized row rowStyle should be used for parent row view style.
      */
-    renderCustomizedRowChild?: (selectedItem: any, index: number) => React.ReactNode;
+    renderCustomizedRowChild?: (selectedItem: any, index: number, isSelected?: boolean) => React.ReactNode;
     /**
      * enable search functionality
      */

--- a/src/SelectDropdown.js
+++ b/src/SelectDropdown.js
@@ -21,6 +21,7 @@ const SelectDropdown = (
     defaultValueByIndex /* integer */,
     disabled /* boolean */,
     disableAutoScroll /* boolean */,
+    disabledIndexs /* array of disabled Row index */,
     onFocus /* function  */,
     onBlur /* function  */,
     onScrollEndReached /* function  */,
@@ -141,6 +142,7 @@ const SelectDropdown = (
     return (
       isExist(item) && (
         <TouchableOpacity
+          disabled={disabledIndexs?.includes(index)}
           activeOpacity={0.8}
           style={{...styles.dropdownRow, ...rowStyle, ...(isSelected && selectedRowStyle)}}
           onPress={() => onSelectItem(item, index)}>

--- a/src/SelectDropdown.js
+++ b/src/SelectDropdown.js
@@ -137,19 +137,20 @@ const SelectDropdown = (
     );
   };
   const renderFlatlistItem = ({item, index}) => {
+    const isSelected = index == selectedIndex;
     return (
       isExist(item) && (
         <TouchableOpacity
           activeOpacity={0.8}
-          style={{...styles.dropdownRow, ...rowStyle, ...(index == selectedIndex && selectedRowStyle)}}
+          style={{...styles.dropdownRow, ...rowStyle, ...(isSelected && selectedRowStyle)}}
           onPress={() => onSelectItem(item, index)}>
           {renderCustomizedRowChild ? (
-            <View style={styles.dropdownCustomizedRowParent}>{renderCustomizedRowChild(item, index, index == selectedIndex)}</View>
+            <View style={styles.dropdownCustomizedRowParent}>{renderCustomizedRowChild(item, index, isSelected)}</View>
           ) : (
             <Text
               numberOfLines={1}
               allowFontScaling={false}
-              style={{...styles.dropdownRowText, ...rowTextStyle, ...(index == selectedIndex && selectedRowTextStyle)}}>
+              style={{...styles.dropdownRowText, ...rowTextStyle, ...(isSelected && selectedRowTextStyle)}}>
               {rowTextForSelection ? rowTextForSelection(item, index) : item.toString()}
             </Text>
           )}

--- a/src/SelectDropdown.js
+++ b/src/SelectDropdown.js
@@ -144,7 +144,7 @@ const SelectDropdown = (
           style={{...styles.dropdownRow, ...rowStyle, ...(index == selectedIndex && selectedRowStyle)}}
           onPress={() => onSelectItem(item, index)}>
           {renderCustomizedRowChild ? (
-            <View style={styles.dropdownCustomizedRowParent}>{renderCustomizedRowChild(item, index)}</View>
+            <View style={styles.dropdownCustomizedRowParent}>{renderCustomizedRowChild(item, index, index == selectedIndex)}</View>
           ) : (
             <Text
               numberOfLines={1}

--- a/src/hooks/useLayoutDropdown.js
+++ b/src/hooks/useLayoutDropdown.js
@@ -44,14 +44,16 @@ export const useLayoutDropdown = (data, dropdownStyle, rowStyle, search) => {
         ? remainigHeightAvoidKeyboard - safeDropdownViewUnderKeyboard
         : dropdownPY;
     return {
+      ...{
+        borderTopWidth: 0,
+        overflow: 'hidden',
+      },
       ...dropdownStyle,
       ...{
         position: 'absolute',
         top: top,
         height: dropdownHEIGHT,
         width: dropdownWIDTH,
-        borderTopWidth: 0,
-        overflow: 'hidden',
       },
       ...(I18nManager.isRTL ? {right: dropdownStyle?.right || dropdownPX} : {left: dropdownStyle?.left || dropdownPX}),
     };


### PR DESCRIPTION
This PR have 3 updates:

- I split style of `dropdownWindowStyle` into 2 parts and move the static (not required) ones on top of `dropdownStyle` so that I can have ability to change these data(in my case, I need to show borderTopWidth)
- I added `isSelected` param to `renderCustomizedRowChild`. We do have some other workarounds on that, but I think this is the fastest way.
- I added `disabledIndexs` so that we can input array of row index that are disabled press