### PR TITLE
Add support for array button style

### DIFF
--- a/src/SelectDropdown.js
+++ b/src/SelectDropdown.js
@@ -2,6 +2,7 @@ import React, {forwardRef, useImperativeHandle} from 'react';
 import {View, Text, TouchableOpacity, FlatList} from 'react-native';
 import styles from './styles';
 import {isExist} from './helpers/isExist';
+import {mergeStyles} from './helpers/mergeStyles';
 import Input from './components/Input';
 import DropdownOverlay from './components/DropdownOverlay';
 import DropdownModal from './components/DropdownModal';
@@ -193,11 +194,11 @@ const SelectDropdown = (
       ref={dropdownButtonRef}
       disabled={disabled}
       onPress={openDropdown}
-      style={{
-        ...styles.dropdownButton,
-        ...(dropdownIconPosition == 'left' ? styles.row : styles.rowRevese),
-        ...buttonStyle,
-      }}>
+      style={mergeStyles(
+        styles.dropdownButton,
+        dropdownIconPosition == 'left' ? styles.row : styles.rowRevese,
+        buttonStyle,
+      )}>
       {renderDropdown()}
       {renderDropdownIcon && renderDropdownIcon(isVisible)}
       {renderCustomizedButtonChild ? (

--- a/src/helpers/mergeStyles.js
+++ b/src/helpers/mergeStyles.js
@@ -1,0 +1,10 @@
+// create a custom function instead of using `StyleSheet.flatten` because we
+// want to make it backward compatible with react-native<0.52.
+export const mergeStyles = (...styles) => {
+  const flattened = styles.flat();
+
+  return flattened.reduce((merged, style) => ({
+    ...merged,
+    ...style,
+  }));
+};


### PR DESCRIPTION
Fix #117 

Implement a custom `mergeStyle` function instead of using the built-in `StyleSheet.flatten` because the function `StyleSheet.flatten` seems to be introduced in `react-native@0.52`, and we want to ensure it's backward compatible after this change.