### PR TITLE
Add support for flexible height

### DIFF
--- a/src/hooks/useLayoutDropdown.js
+++ b/src/hooks/useLayoutDropdown.js
@@ -14,7 +14,8 @@ export const useLayoutDropdown = (data, dropdownStyle, rowStyle, search) => {
   }); // dropdown height
   const [dropdownWIDTH, setDropdownWIDTH] = useState(0); // dropdown width
   const remainigHeightAvoidKeyboard = useKeyboardRemainingScreenHeight();
-  const safeDropdownViewUnderKeyboard = rowStyle && rowStyle.height ? rowStyle.height * 3 : 50 * 3;
+  const safeDropdownViewUnderKeyboard = rowStyle && rowStyle.height ? rowStyle.height * 3 :
+    rowStyle && rowStyle.minHeight ? rowStyle.minHeight * 3 : 50 * 3;
 
   useEffect(() => {
     setDropdownHEIGHT(calculateDropdownHeight(dropdownStyle, rowStyle, data?.length || 0, search));


### PR DESCRIPTION
The height of the dropdown row is fixed at 50. So longer options are getting truncated in the dropdown. 
<img width="190" alt="Screenshot 2023-04-19 at 1 40 36 PM" src="https://user-images.githubusercontent.com/104359410/233012204-0157cfc7-785c-4e07-936e-4adb31737f8f.png">

In our usecase, the row height should be 25 but for longer options, the height should be flexible. So we pass customized rowStlye prop as { height: null, minheight: 25 }. It works as expected.
<img width="190" alt="Screenshot 2023-04-19 at 1 40 52 PM" src="https://user-images.githubusercontent.com/104359410/233012295-ab4be40d-3c05-4f6a-87be-4fd8e939c9ce.png">


But the top position is miscalculated when the dropdown position is on top as safeDropdownViewUnderKeyboard is calculated only using height value which is hardcoded as 50. The dropdown opens at a random position from the select button
<img width="190" alt="Screenshot 2023-04-19 at 1 41 08 PM" src="https://user-images.githubusercontent.com/104359410/233012316-04ce67c9-b5fd-4215-96e3-14c70eae6d8e.png">

To fix the above, modified the safeDropdownViewUnderKeyboard calculation to also check for minHeight when height is not passed. The issue is fixed as in below screenshot. Therefore proposing to use min height also to calculate for top position instead of just height.
<img width="190" alt="Screenshot 2023-04-19 at 1 41 21 PM" src="https://user-images.githubusercontent.com/104359410/233012333-2a4f5404-6cf7-4111-bb4f-9a9960ca757f.png">



