### PR TITLE
Fix: The item in renderCustomizedButtonChild is always null when fetching data

### DIFF
--- a/src/hooks/useSelectDropdown.js
+++ b/src/hooks/useSelectDropdown.js
@@ -23,7 +23,7 @@ export const useSelectDropdown = (data, defaultValueByIndex, defaultValue, disab
         selectItem(defaultValueByIndex);
       }
     }
-  }, [JSON.stringify(defaultValueByIndex)]);
+  }, [JSON.stringify(defaultValueByIndex), data]);
   // default value added or changed
   useEffect(() => {
     // defaultValue may be equals zero
@@ -32,7 +32,7 @@ export const useSelectDropdown = (data, defaultValueByIndex, defaultValue, disab
         selectItem(findIndexInArr(defaultValue, data));
       }
     }
-  }, [JSON.stringify(defaultValue)]);
+  }, [JSON.stringify(defaultValue), data]);
 
   const dataArr = useMemo(() => {
     if (disabledInternalSearch) {


### PR DESCRIPTION
fix: `data` should be used as a dependency of useEffect