### PR TITLE
adjust: useLayoutDropdown detect width overflow and fit button

### DIFF
--- a/src/hooks/useLayoutDropdown.js
+++ b/src/hooks/useLayoutDropdown.js
@@ -25,19 +25,20 @@ export const useLayoutDropdown = (data, dropdownStyle) => {
 
     const remainingHeight = dropdownStyle?.height || height / 4;
     const dropdownWIDTH = dropdownStyle?.width || w
+    const isWidthOverflow = dropdownWIDTH + px > width 
 
     if (py + h > height - remainingHeight) {
       return setDropdownCalculatedStyle({
         bottom: height - (py + h) + h,
         width: dropdownWIDTH,
-        ...(I18nManager.isRTL ? {right: dropdownStyle?.right || px} : {left: dropdownStyle?.left || px}),
+        ...(I18nManager.isRTL ? {right: dropdownStyle?.right || px} : {left: dropdownStyle?.left || (isWidthOverflow ? px - dropdownWIDTH + (dropdownStyle?.right || 0): px)}),
       });
     }
 
     return setDropdownCalculatedStyle({
       top: py + h + 2,
       width: dropdownWIDTH,
-      ...(I18nManager.isRTL ? {right: dropdownStyle?.right || px} : {left: dropdownStyle?.left || px}),
+      ...(I18nManager.isRTL ? {right: dropdownStyle?.right || px} : {left: dropdownStyle?.left || (isWidthOverflow ? px - dropdownWIDTH + (dropdownStyle?.right || 0): px)}),
     });
   };
 

--- a/src/hooks/useLayoutDropdown.js
+++ b/src/hooks/useLayoutDropdown.js
@@ -24,18 +24,19 @@ export const useLayoutDropdown = (data, dropdownStyle) => {
     setButtonLayout({w, h, px, py});
 
     const remainingHeight = dropdownStyle?.height || height / 4;
+    const dropdownWIDTH = dropdownStyle?.width || w
 
     if (py + h > height - remainingHeight) {
       return setDropdownCalculatedStyle({
         bottom: height - (py + h) + h,
-        width: dropdownStyle?.width || w,
+        width: dropdownWIDTH,
         ...(I18nManager.isRTL ? {right: dropdownStyle?.right || px} : {left: dropdownStyle?.left || px}),
       });
     }
 
     return setDropdownCalculatedStyle({
       top: py + h + 2,
-      width: dropdownStyle?.width || w,
+      width: dropdownWIDTH,
       ...(I18nManager.isRTL ? {right: dropdownStyle?.right || px} : {left: dropdownStyle?.left || px}),
     });
   };


### PR DESCRIPTION

Dropdown maybe overflow (Image 1) 
I adjust code to fit button. (Image 2)
Adn User can add `right` in dropdownStyle to fit its button (Image 3)

| 1 | 2 | 3 |
|----------|----------|----------|
| ![1](https://github.com/AdelRedaa97/react-native-select-dropdown/assets/9431852/c4d183c1-b377-4361-b3b7-39c9591bfb70)  |  ![2](https://github.com/AdelRedaa97/react-native-select-dropdown/assets/9431852/a667f5dd-a47a-400f-b800-88276b92713d) |  ![3](https://github.com/AdelRedaa97/react-native-select-dropdown/assets/9431852/77b1e3b8-60c2-4dc0-827f-0c5e1e5a708b) |
